### PR TITLE
add install and run scripts for running in a PRoot env (Termux)

### DIFF
--- a/termux-proot-distro-install/install.sh
+++ b/termux-proot-distro-install/install.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# Commands needed to run once to install Anki in a proot-distro OS. Keeps the run script faster
+
+# Variables file used to configure behavior of the install and run scripts
+. ./variables.sh
+
+# fyi Termux's pacakge manager "pkg" is a wrapper around apt.
+# apt does have an option to automatically upgrade packages (--assume-yes) but I don't think this should be used.
+pkg upgrade
+pkg install "$TERMUX_PACKAGES"
+proot-distro install "$DISTRO"
+# From this point on we run code in the proot environment and not Termux itself 
+
+# Qt (and thus Anki) doesn't like running as an user named root, even if it is a fake root like proot.
+run_command_in_proot root adduser --disabled-password --gecos "" "$ANKI_INSTALL_USER"
+
+# Anki requires an X server at minumum and a somewhat intuitive window manager to be useable. My preference for the X server is tigervnc and to connect to it with a VNC client for Android. For the window manager, xfwm4 fron Xfce will do. Customization/use of lighter-weight software can be done here.
+X_PACKAGES="tigervnc-standalone-server xfce4"
+
+# Anki dependencies
+run_command_in_proot root apt install python3-pyqt5.qtwebengine python3-pyqt5.qtmultimedia $X_PACKAGES
+
+# Get the latest Anki stable release via pip - https://betas.ankiweb.net/#via-pypipip
+run_command_in_proot "$ANKI_INSTALL_USER" python3.9 -m venv --system-site-packages pyenv
+
+# The following is recommended by  the instructions above, but seems to be broken due to: https://github.com/pypa/pip/issues/10887
+#run_command_in_proot "$ANKI_INSTALL_USER" pyenv/bin/pip install --upgrade pip
+
+# note adding --pre flag after pip install will get the latest beta. without it, get the latest stable 
+run_command_in_proot "$ANKI_INSTALL_USER" pyenv/bin/pip install --upgrade aqt
+
+#TODO copy run.sh to the user's PATH
+#TODO handle existing users upgrading their anki using pip

--- a/termux-proot-distro-install/run-anki.sh
+++ b/termux-proot-distro-install/run-anki.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+# a script to setup the proot environment for anki.
+
+export DISPLAY=":1"
+
+# A couple hacks for Qt to work
+export QTWEBENGINE_CHROMIUM_FLAGS="--disable-gpu"
+
+# Disabling sandbox is a security risk, but we might not have to do this when Anki goes to Qt 6.2
+# https://forums.ankiweb.net/t/setting-disable-seccomp-filter-sandbox-by-default-on-linux/13765
+export QTWEBENGINE_DISABLE_SANDBOX=1
+
+# Connections are bound to localhost for security, but some interesting configs could be made via ssh port forwarding
+tigervncserver -localhost -xstartup /usr/bin/xfce4-session $DISPLAY
+
+/home/anki-user/pyenv/bin/anki
+
+#TODO `am start` to start a vnc-viewer app would be a nice touch
+

--- a/termux-proot-distro-install/variables.sh
+++ b/termux-proot-distro-install/variables.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# Variables used by install and run scripts
+
+# Bit of a misnomer because it's not a variable, but install and run scripts also need this function
+# $1 - logs in as a particular user in the proot (note root is the root user in the proot, not android)
+# $@ - command(s) to run as that user
+run_command_in_proot (){
+    COMMAND_USER="$1"
+    shift 1
+    # if you run into issues, try removing --isolated
+    proot-distro login --isolated --user "$COMMAND_USER" "$DISTRO" -- "$@"
+}
+
+# Package(s) needed in vanilla Termux
+TERMUX_PACKAGES="proot-distro"
+
+# proot-distro distribution to install. At the time of this writing, every option has a wrong version of libc that anki needs, with the exception of Ubuntu. This could change.
+DISTRO="ubuntu"
+
+# User to install anki under in the proot environment. Probably only useful to existing proot-distro users that have $DISTRO installed
+ANKI_INSTALL_USER="anki-user"


### PR DESCRIPTION
Previously discussed install and run scripts for Anki in a Ubuntu proot-distro in Termux.

There's of course limitations:
1. arm-64 only, 
2. android 7+ only (Termux's minimum android version), 
3. enough internal storage to handle proot-distro (Ubuntu, a window manager, and of course Anki in addition to the collection

I haven't yet tested this on a completely fresh install of Termux and proot-ubuntu. Iirc there was a missing python module in the install which the anki docs didn't cover. I had to install it via pip. Sorry I don't have the name- it didn't show up in my .bash_history for some reason.

P.s. it gets the stable anki release from pip rather than `wget`ing it from GitHub- should save you work rebuilding every time there's a new stable release